### PR TITLE
add option to choose language for syntax highlighting when invoking ed

### DIFF
--- a/src/ed.h
+++ b/src/ed.h
@@ -108,6 +108,7 @@ int write_file( const char * const filename, const char * const mode,
                 const int from, const int to );
 void reset_unterminated_line( void );
 void unmark_unterminated_line( const line_t * const lp );
+bool set_lang( const char* const s );
 
 /* defined in main.c */
 bool extended_regexp( void );

--- a/src/io.c
+++ b/src/io.c
@@ -27,10 +27,20 @@
 
 static const line_t * unterminated_line = 0;	/* last line has no '\n' */
 static int linenum_ = 0;			/* script line number */
+static const char* lang = "cpp.lang";  /* argument for source-highlight */
 
 int linenum( void ) { return linenum_; }
 
 void reset_unterminated_line( void ) { unterminated_line = 0; }
+
+bool set_lang( const char* const s )
+ {
+ static char buf[516];
+ const int len = strlen( s );
+ memcpy( buf, s, len + 1 );
+ lang = buf;
+ return true;
+ }
 
 void unmark_unterminated_line( const line_t * const lp )
   { if( unterminated_line == lp ) unterminated_line = 0; }
@@ -46,7 +56,7 @@ static void print_line( const char * p, int len, const int pflags )
 
   char out[1000];
   int nbytes;
-  highlight(p, len, out, &nbytes);
+  highlight(p, len, out, &nbytes, lang);
   p = out;
   len = nbytes;
 

--- a/src/main.c
+++ b/src/main.c
@@ -41,7 +41,6 @@
 #include "carg_parser.h"
 #include "ed.h"
 
-
 static const char * const program_name = "ed";
 static const char * const program_year = "2022";
 static const char * invocation_name = "ed";		/* default value */
@@ -73,6 +72,7 @@ static void show_help( void )
           "\nUsage: %s [options] [file]\n", invocation_name );
   printf( "\nOptions:\n"
           "  -h, --help                 display this help and exit\n"
+	  "  -H, --highlight            set language for source-highlight\n"
           "  -V, --version              output version information and exit\n"
           "  -E, --extended-regexp      use extended regular expressions\n"
           "  -G, --traditional          run in compatibility mode\n"
@@ -158,6 +158,7 @@ int main( const int argc, const char * const argv[] )
     { 'E', "extended-regexp",      ap_no  },
     { 'G', "traditional",          ap_no  },
     { 'h', "help",                 ap_no  },
+    { 'H', "highlight",            ap_yes },
     { 'l', "loose-exit-status",    ap_no  },
     { 'p', "prompt",               ap_yes },
     { 'r', "restricted",           ap_no  },
@@ -186,6 +187,7 @@ int main( const int argc, const char * const argv[] )
       case 'E': extended_regexp_ = true; break;
       case 'G': traditional_ = true; break;	/* backward compatibility */
       case 'h': show_help(); return 0;
+      case 'H': if( set_lang( arg ) ) break; else return 1;
       case 'l': loose = true; break;
       case 'p': if( set_prompt( arg ) ) break; else return 1;
       case 'r': restricted_ = true; break;

--- a/src/sh.cpp
+++ b/src/sh.cpp
@@ -16,6 +16,7 @@
 #include "srchilite/sourcehighlight.h"
 
 #include <sstream>
+#include <string.h>
 
 
 // we highlight to the console, through ANSI escape sequences
@@ -23,11 +24,11 @@ static srchilite::SourceHighlight sourceHighlight("esc.outlang");
 static std::stringstream ips, ops;
 
 // assume out is preallocated to at least 1000 characters
-void highlight(const char* input, int len, char* out, int* nchar) {
+void highlight(const char* input, int len, char* out, int* nchar, const char* lang) {
     ips.clear();
     ops.clear();
     for (int i = 0; i < len; i++) ips << input[i];
-    sourceHighlight.highlight(ips, ops, "cpp.lang");
+    sourceHighlight.highlight(ips, ops, lang);
     int bytesWritten = 0;
     for (char c; ops.get(c) && bytesWritten < 999; ) 
         out[bytesWritten++] = c;

--- a/src/sh.h
+++ b/src/sh.h
@@ -18,4 +18,5 @@
 extern "C"
 #endif
 
-void highlight(const char* input, int len, char* out, int* nchar);
+void highlight(const char* input, int len, char* out, int* nchar, const char* lang);
+


### PR DESCRIPTION
Added the option `-H` or `--highlight` to set a target language for syntax highlighting. The default language is kept "cpp.lang" as in the original version.

Example usage:
`ed -H"fortran.lang" file.f90`

Modified the files: 
+ `sh.cpp`, `sh.h` -- extend the `highlight`-method signature with a language argument
+ `io.c` -- store language argument and call `highlight` with the appropriate language argument
+ `main.c` -- read in the option and set the target language